### PR TITLE
chore: Consolidate localizationsDelegates

### DIFF
--- a/packages/core/lib/constants/localizations_delegates.dart
+++ b/packages/core/lib/constants/localizations_delegates.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+final localizationsDelegates = [
+  GlobalCupertinoLocalizations.delegate,
+  GlobalMaterialLocalizations.delegate,
+  GlobalWidgetsLocalizations.delegate,
+];

--- a/packages/core/lib/core.dart
+++ b/packages/core/lib/core.dart
@@ -2,6 +2,7 @@ export 'common_widgets/my_smooth_page_indicator.dart';
 export 'common_widgets/show_my_progress_indicator.dart';
 export 'constants/app_env.dart';
 export 'constants/global_keys.dart';
+export 'constants/localizations_delegates.dart';
 export 'constants/remote_config_constant.dart';
 export 'constants/typedefs.dart';
 export 'extensions/cupertino_text_theme_data_extension.dart';

--- a/packages/core/lib/features/configure/presentation/failed_run_app_page.dart
+++ b/packages/core/lib/features/configure/presentation/failed_run_app_page.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
+import 'package:core/constants/localizations_delegates.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:core/utils/inherited_theme_detector.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 
 class FailedRunAppPage extends StatelessWidget {
   const FailedRunAppPage({
@@ -21,21 +21,13 @@ class FailedRunAppPage extends StatelessWidget {
       InheritedThemeType.material => MaterialApp(
           supportedLocales: AppLocaleUtils.supportedLocales,
           debugShowCheckedModeBanner: false,
-          localizationsDelegates: const [
-            GlobalCupertinoLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
+          localizationsDelegates: localizationsDelegates,
           home: const FailedRunAppPageHome(),
         ),
       InheritedThemeType.cupertino => CupertinoApp(
           supportedLocales: AppLocaleUtils.supportedLocales,
           debugShowCheckedModeBanner: false,
-          localizationsDelegates: const [
-            GlobalCupertinoLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
+          localizationsDelegates: localizationsDelegates,
           home: const FailedRunAppPageHome(),
         ),
     };

--- a/packages/core/lib/features/configure/presentation/update_app_page.dart
+++ b/packages/core/lib/features/configure/presentation/update_app_page.dart
@@ -2,7 +2,6 @@ import 'package:core/core.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -23,11 +22,7 @@ class UpdateAppPage extends HookConsumerWidget {
     return switch (themeType) {
       InheritedThemeType.material => MaterialApp(
           supportedLocales: AppLocaleUtils.supportedLocales,
-          localizationsDelegates: const [
-            GlobalCupertinoLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
+          localizationsDelegates: localizationsDelegates,
           debugShowCheckedModeBanner: false,
           home: UpdateAppPageHome(
             force: force,
@@ -35,11 +30,7 @@ class UpdateAppPage extends HookConsumerWidget {
         ),
       InheritedThemeType.cupertino => CupertinoApp(
           supportedLocales: AppLocaleUtils.supportedLocales,
-          localizationsDelegates: const [
-            GlobalCupertinoLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
+          localizationsDelegates: localizationsDelegates,
           debugShowCheckedModeBanner: false,
           home: UpdateAppPageHome(
             force: force,

--- a/packages/core/test/coverage_test.dart
+++ b/packages/core/test/coverage_test.dart
@@ -2,6 +2,7 @@
 import 'package:core/common_widgets/my_smooth_page_indicator.dart';
 import 'package:core/common_widgets/show_my_progress_indicator.dart';
 import 'package:core/constants/collection_path.dart';
+import 'package:core/constants/localizations_delegates.dart';
 import 'package:core/extensions/cupertino_text_theme_data_extension.dart';
 import 'package:core/extensions/go_router_extension.dart';
 import 'package:core/features/ads/application/ads_providers.dart';

--- a/packages/listen_to_music_by_location/lib/my_app.dart
+++ b/packages/listen_to_music_by_location/lib/my_app.dart
@@ -1,6 +1,5 @@
 import 'package:core/core.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:listen_to_music_by_location/features/home/application/home_route.dart'
     as home_route;
@@ -30,12 +29,6 @@ class MyApp extends HookConsumerWidget {
       darkColor: Color(0xFFFB5C74),
     ),
   );
-
-  static final localizationsDelegates = [
-    GlobalCupertinoLocalizations.delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
I consolidated the `localizationsDelegates` into a separate file to improve code organization and reusability. This change reduces code duplication and makes it easier to manage and update the list of delegates.