### PR TITLE
feat: Add exception handling for credential already in use

### DIFF
--- a/packages/core/lib/core.dart
+++ b/packages/core/lib/core.dart
@@ -11,6 +11,7 @@ export 'features/ads/application/ads_providers.dart';
 export 'features/ads/presentation/my_adaptive_banner_ad.dart';
 export 'features/authentication/application/firebase_user_providers.dart';
 export 'features/authentication/application/my_auth_provider.dart';
+export 'features/authentication/exception/credential_already_in_use_exception.dart';
 export 'features/authentication/presentation/my_auth_provider_button.dart';
 export 'features/authentication/presentation/my_auth_provider_buttons.dart';
 export 'features/configure/application/configure_providers.dart';

--- a/packages/core/lib/features/authentication/application/my_auth_provider.dart
+++ b/packages/core/lib/features/authentication/application/my_auth_provider.dart
@@ -1,5 +1,4 @@
 import 'package:core/core.dart';
-import 'package:core/features/authentication/exception/credential_already_in_use_exception.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';

--- a/packages/core/lib/features/authentication/application/my_auth_provider.dart
+++ b/packages/core/lib/features/authentication/application/my_auth_provider.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:core/features/authentication/exception/credential_already_in_use_exception.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -28,7 +29,7 @@ class MyAuthProviderController extends _$MyAuthProviderController {
       } else {
         await ref.watch(firebaseAuthProvider).signInWithProvider(state);
       }
-    } on Exception catch (exception) {
+    } on Exception catch (exception, stack) {
       if (exception is FirebaseAuthException) {
         switch (exception.code) {
           case 'web-context-cancelled':
@@ -52,12 +53,24 @@ class MyAuthProviderController extends _$MyAuthProviderController {
               },
             );
             return;
+
+          case 'credential-already-in-use':
+            logger.info(
+              {
+                'message': 'credentialAlreadyInUse',
+                'providerId': state.providerId,
+                'exceptionMessage': exception.message,
+                'exceptionCode': exception.code,
+              },
+            );
+
+            throw CredentialAlreadyInUseException(type);
         }
       }
 
       logger.handle(
         exception,
-        StackTrace.current,
+        stack,
         'provider id: ${state.providerId}',
       );
     }

--- a/packages/core/lib/features/authentication/application/my_auth_provider.g.dart
+++ b/packages/core/lib/features/authentication/application/my_auth_provider.g.dart
@@ -161,7 +161,7 @@ class _MyAuthProviderIsLinkedProviderElement
 }
 
 String _$myAuthProviderControllerHash() =>
-    r'8339f7d263e1d7a1e37e14475d2416f849b98fb1';
+    r'e2eaa7e3bd32e6ca811f69b83d7cf7d2ce340262';
 
 abstract class _$MyAuthProviderController
     extends BuildlessAutoDisposeNotifier<AuthProvider> {

--- a/packages/core/lib/features/authentication/exception/credential_already_in_use_exception.dart
+++ b/packages/core/lib/features/authentication/exception/credential_already_in_use_exception.dart
@@ -1,0 +1,7 @@
+import 'package:core/features/authentication/application/my_auth_provider.dart';
+
+class CredentialAlreadyInUseException implements Exception {
+  CredentialAlreadyInUseException(this.type);
+
+  final MyAuthProviderType type;
+}

--- a/packages/core/lib/features/authentication/presentation/my_auth_provider_button.dart
+++ b/packages/core/lib/features/authentication/presentation/my_auth_provider_button.dart
@@ -2,6 +2,7 @@
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:core/core.dart';
+import 'package:core/features/authentication/exception/credential_already_in_use_exception.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -71,6 +72,22 @@ class MyAuthProviderButton extends HookConsumerWidget {
                     await authProviderController.signInOrLink();
                   }
                 } on Exception catch (e, stack) {
+                  if (e is CredentialAlreadyInUseException) {
+                    final providerName = e.type.providerName;
+
+                    if (context.mounted) {
+                      await showOkAlertDialog(
+                        context: context,
+                        title: i18n.auth.credential_already_in_use_exception,
+                        message: i18n.auth
+                            .credential_already_in_use_exception_message(
+                          providerName: providerName,
+                        ),
+                      );
+                      return;
+                    }
+                  }
+
                   logger.handle(e, stack);
 
                   if (context.mounted) {

--- a/packages/core/lib/features/authentication/presentation/my_auth_provider_button.dart
+++ b/packages/core/lib/features/authentication/presentation/my_auth_provider_button.dart
@@ -2,7 +2,6 @@
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:core/core.dart';
-import 'package:core/features/authentication/exception/credential_already_in_use_exception.dart';
 import 'package:core/gen/strings.g.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/packages/core/lib/gen/strings.g.dart
+++ b/packages/core/lib/gen/strings.g.dart
@@ -270,6 +270,8 @@ class _StringsAuthJa {
 	String get sign_out_complete => 'サインアウトしました';
 	String get exception => '予期せぬエラーが発生しました';
 	String get exception_message => 'しばらく時間を置いてから再度お試しください。';
+	String get credential_already_in_use_exception => 'アカウントを接続できません';
+	String credential_already_in_use_exception_message({required Object providerName}) => 'この${providerName}はすでに他のユーザーに接続されています。他の${providerName}を使用してください。';
 }
 
 // Path: onboarding
@@ -484,6 +486,8 @@ class _StringsAuthEn extends _StringsAuthJa {
 	@override String get sign_out_complete => 'Signed out successfully';
 	@override String get exception => 'An unexpected error occurred';
 	@override String get exception_message => 'Please try again after a while.';
+	@override String get credential_already_in_use_exception => 'Account already in use';
+	@override String credential_already_in_use_exception_message({required Object providerName}) => 'This ${providerName} is already connected to another user. Please use a different ${providerName}.';
 }
 
 // Path: onboarding

--- a/packages/core/lib/i18n/strings_en.i18n.json
+++ b/packages/core/lib/i18n/strings_en.i18n.json
@@ -76,8 +76,10 @@
     "sign_out_description": "When you sign out, you will no longer have access to the data you are currently using unless you are connected to an account.",
     "sign_out_complete": "Signed out successfully",
     "exception": "An unexpected error occurred",
-    "exception_message": "Please try again after a while."
-  },
+    "exception_message": "Please try again after a while.",
+    "credential_already_in_use_exception": "Account already in use",
+    "credential_already_in_use_exception_message": "This ${providerName} is already connected to another user. Please use a different ${providerName}."
+    },
   "onboarding": {
     "start": "Start",
     "social_account_sign_in": "Sign in with Social Account",

--- a/packages/core/lib/i18n/strings_ja.i18n.json
+++ b/packages/core/lib/i18n/strings_ja.i18n.json
@@ -76,7 +76,9 @@
     "sign_out_description": "サインアウトすると、アカウントを接続していない場合は現在利用中のデータにアクセスできなくなります。",
     "sign_out_complete": "サインアウトしました",
     "exception": "予期せぬエラーが発生しました",
-    "exception_message": "しばらく時間を置いてから再度お試しください。"
+    "exception_message": "しばらく時間を置いてから再度お試しください。",
+    "credential_already_in_use_exception": "アカウントを接続できません",
+    "credential_already_in_use_exception_message": "この${providerName}はすでに他のユーザーに接続されています。他の${providerName}を使用してください。"
   },
   "onboarding": {
     "start": "はじめる",

--- a/packages/core/test/coverage_test.dart
+++ b/packages/core/test/coverage_test.dart
@@ -9,6 +9,7 @@ import 'package:core/features/ads/application/ads_providers.dart';
 import 'package:core/features/ads/presentation/my_adaptive_banner_ad.dart';
 import 'package:core/features/authentication/application/firebase_user_providers.dart';
 import 'package:core/features/authentication/application/my_auth_provider.dart';
+import 'package:core/features/authentication/exception/credential_already_in_use_exception.dart';
 import 'package:core/features/authentication/presentation/my_auth_provider_button.dart';
 import 'package:core/features/authentication/presentation/my_auth_provider_buttons.dart';
 import 'package:core/features/configure/application/configure_providers.dart';


### PR DESCRIPTION
This pull request adds exception handling for the "credential already in use" scenario in the authentication feature.

It introduces a new `CredentialAlreadyInUseException` class and updates the relevant code to throw this exception when necessary.

Additionally, it includes updated translations for the error message in both English and Japanese.