### PR TITLE
ci: run jobs only when necessary

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -169,9 +169,33 @@ jobs:
           name: golden_failures
           path: packages/*/test/**/failures/
 
+  changed-files:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    outputs:
+      app_pubspec_changed: steps.required_pod_install.outputs.app_pubspec_changed
+      firebase_changed: steps.required_pod_install.outputs.firebase_changed
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_yaml: |
+            app_pubspec:
+              - packages/*/pubspec.yaml
+            firebase:
+              - firebase.json
+              - firebase/**
+
   pod_install:
     timeout-minutes: 60
     runs-on: macos-14
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.app_pubspec_changed == 'true' }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0
@@ -210,6 +234,8 @@ jobs:
     permissions: # for KoheiKanagu/composite-actions/setup-firebase-cli@main
       id-token: write
       contents: read
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.firebase_changed == 'true' }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,6 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed-files:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    outputs:
+      app_pubspec_any_changed: ${{ steps.changed-files.outputs.app_pubspec_any_changed == 'true' }}
+      firebase_any_changed: ${{ steps.changed-files.outputs.firebase_any_changed == 'true' }}
+      update_si_any_changed: ${{ steps.changed-files.outputs.update_si_any_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_yaml: |
+            app_pubspec:
+              - packages/*/pubspec.yaml
+            firebase:
+              - firebase.json
+              - firebase/**
+            update_si:
+              - packages/*/assets/svg/*
+              - packages/*/assets/si/*
+              - packages/*/pubspec.yaml
+
   generate:
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -45,6 +72,8 @@ jobs:
   update-si:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.update_si_any_changed == 'true' }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0
@@ -169,33 +198,11 @@ jobs:
           name: golden_failures
           path: packages/*/test/**/failures/
 
-  changed-files:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    outputs:
-      app_pubspec_changed: steps.required_pod_install.outputs.app_pubspec_changed
-      firebase_changed: steps.required_pod_install.outputs.firebase_changed
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files_yaml: |
-            app_pubspec:
-              - packages/*/pubspec.yaml
-            firebase:
-              - firebase.json
-              - firebase/**
-
   pod_install:
     timeout-minutes: 60
     runs-on: macos-14
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.app_pubspec_changed == 'true' }}
+    if: ${{ needs.changed-files.outputs.app_pubspec_any_changed == 'true' }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0
@@ -235,7 +242,7 @@ jobs:
       id-token: write
       contents: read
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.firebase_changed == 'true' }}
+    if: ${{ needs.changed-files.outputs.firebase_any_changed == 'true' }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0


### PR DESCRIPTION
This pull request optimizes the CI workflow by introducing a new step called "changed-files" that retrieves the list of changed files.

This step is then used in the "pod_install" and "firebase_deploy" steps to conditionally run only when necessary.

This reduces unnecessary execution and improves the overall efficiency of the CI process.