### PR TITLE
build: direct main

### DIFF
--- a/packages/listen_to_music_by_location/pubspec.lock
+++ b/packages/listen_to_music_by_location/pubspec.lock
@@ -106,7 +106,7 @@ packages:
     source: hosted
     version: "2.1.1"
   budoux_dart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: budoux_dart
       sha256: "7211cfa7bc38beb00d1dfe9d1b9016a6089b0b84b45d6b0b20f66bf8dbd6ef3b"
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "0.4.1"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
@@ -266,7 +266,7 @@ packages:
     source: hosted
     version: "3.12.5"
   cloud_functions:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cloud_functions
       sha256: ddec68a2fbee603527c009bb20c6bd071559dfa87fda55d9d92052d1ebff5377
@@ -369,7 +369,7 @@ packages:
     source: hosted
     version: "5.1.1"
   cupertino_icons:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cupertino_icons
       sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
@@ -417,7 +417,7 @@ packages:
     source: hosted
     version: "1.2.0"
   device_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: device_info_plus
       sha256: eead12d1a1ed83d8283ab4c2f3fca23ac4082f29f25f29dff0f758f57d06ec91
@@ -457,7 +457,7 @@ packages:
     source: hosted
     version: "1.3.1"
   feedback:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: feedback
       sha256: "26769f73de6215add72074d24e4a23542e4c02a8fd1a873e7c93da5dc9c1d362"
@@ -505,7 +505,7 @@ packages:
     source: hosted
     version: "0.5.7+7"
   firebase_app_check:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_app_check
       sha256: aac3b42cdf804b10cb1085c9902e5d1ef2f30e7cfc0c504e6f47519713d86829
@@ -529,7 +529,7 @@ packages:
     source: hosted
     version: "0.1.2+7"
   firebase_auth:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_auth
       sha256: cfc2d970829202eca09e2896f0a5aa7c87302817ecc0bdfa954f026046bf10ba
@@ -553,7 +553,7 @@ packages:
     source: hosted
     version: "5.12.0"
   firebase_core:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core
       sha256: "26de145bb9688a90962faec6f838247377b0b0d32cc0abecd9a4e43525fc856c"
@@ -577,7 +577,7 @@ packages:
     source: hosted
     version: "2.17.0"
   firebase_crashlytics:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_crashlytics
       sha256: "9897c01efaa950d2f6da8317d12452749a74dc45f33b46390a14cfe28067f271"
@@ -593,7 +593,7 @@ packages:
     source: hosted
     version: "3.6.35"
   firebase_performance:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_performance
       sha256: dbcfc300755c4bb866988de20a491f0b53e1a0d14c375a2c31aa53ca82174c5b
@@ -617,7 +617,7 @@ packages:
     source: hosted
     version: "0.1.6+7"
   firebase_remote_config:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_remote_config
       sha256: "653bd94b68e2c4e89eca10db90576101f1024151f39f2d4e7c64ae6a90a5f9c5"
@@ -649,7 +649,7 @@ packages:
     source: hosted
     version: "1.1.0"
   flex_color_scheme:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flex_color_scheme
       sha256: "32914024a4f404d90ff449f58d279191675b28e7c08824046baf06826e99d984"
@@ -789,7 +789,7 @@ packages:
     source: hosted
     version: "2.7.0"
   google_mobile_ads:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_mobile_ads
       sha256: e2d18992d30b2be77cb6976b931112fc3c4612feffb5eb7a8b036bd7a64934da
@@ -901,7 +901,7 @@ packages:
     source: hosted
     version: "2.1.3"
   in_app_review:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: in_app_review
       sha256: "99869244d09adc76af16bf8fd731dd13cef58ecafd5917847589c49f378cbb30"
@@ -973,7 +973,7 @@ packages:
     source: hosted
     version: "3.0.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
@@ -1101,7 +1101,7 @@ packages:
     source: hosted
     version: "2.1.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
@@ -1245,7 +1245,7 @@ packages:
     source: hosted
     version: "1.3.0"
   quick_actions:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quick_actions
       sha256: b17da113df7a7005977f64adfa58ccc49c829d3ccc6e8e770079a8c7fbf2da9e
@@ -1341,7 +1341,7 @@ packages:
     source: hosted
     version: "4.0.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
@@ -1434,7 +1434,7 @@ packages:
     source: sdk
     version: "0.0.99"
   slang:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: slang
       sha256: "0d8a8cbfd7858ed2bd9164a79bfb664ea83f1e124740b28acd0618757fc87ecc"
@@ -1450,7 +1450,7 @@ packages:
     source: hosted
     version: "3.31.0"
   slang_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: slang_flutter
       sha256: f8400292be49c11697d94af58d7f7d054c91af759f41ffe71e4e5413871ffc62
@@ -1458,7 +1458,7 @@ packages:
     source: hosted
     version: "3.31.0"
   smooth_page_indicator:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: smooth_page_indicator
       sha256: "725bc638d5e79df0c84658e1291449996943f93bacbc2cec49963dbbab48d8ae"
@@ -1578,7 +1578,7 @@ packages:
     source: hosted
     version: "3.1.0+1"
   talker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker
       sha256: f876081a34027464e3f1ac785c7e470a5fca2515f4c8c277fb6f78a63e5cda1e
@@ -1586,7 +1586,7 @@ packages:
     source: hosted
     version: "4.2.3"
   talker_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker_flutter
       sha256: "45dab03948d8a611b97d396a782497d567f8fa5694466a2d306f84cfffca6910"
@@ -1602,7 +1602,7 @@ packages:
     source: hosted
     version: "4.2.3"
   talker_riverpod_logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker_riverpod_logger
       sha256: "186c4cd71abc7d15e661d0a2011d0208c860f12ec1359638cfd335f95925d505"
@@ -1738,7 +1738,7 @@ packages:
     source: hosted
     version: "3.1.1"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"

--- a/packages/listen_to_music_by_location/pubspec.yaml
+++ b/packages/listen_to_music_by_location/pubspec.yaml
@@ -10,12 +10,25 @@ environment:
 dependencies:
   adaptive_dialog: ^2.1.0
   app_links: ^6.1.1
+  budoux_dart: ^1.2.0
   cached_network_image: ^3.3.1
+  clock: ^1.1.1
   cloud_firestore: ^4.17.5
+  cloud_functions: ^4.7.6
   collection: ^1.18.0
   core:
     path: ../core
+  cupertino_icons: ^1.0.8
+  device_info_plus: ^10.1.0
+  feedback: ^3.1.0
   firebase_analytics: ^10.10.7
+  firebase_app_check: ^0.2.2+7
+  firebase_auth: ^4.20.0
+  firebase_core: ^2.32.0
+  firebase_crashlytics: ^3.5.7
+  firebase_performance: ^0.9.4+7
+  firebase_remote_config: ^4.4.7
+  flex_color_scheme: ^7.3.1
   flutter:
     sdk: flutter
   flutter_hooks: ^0.20.5
@@ -24,12 +37,25 @@ dependencies:
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
   go_router: ^14.1.4
+  google_mobile_ads: ^5.1.0
   hooks_riverpod: ^2.5.1
+  in_app_review: ^2.0.9
   intersperse: ^2.0.0
   intl: any
   jovial_svg: ^1.1.21
+  json_annotation: ^4.9.0
+  package_info_plus: ^8.0.0
+  quick_actions: ^1.0.7
   riverpod_annotation: ^2.3.5
+  shared_preferences: ^2.2.3
+  slang: ^3.31.0
+  slang_flutter: ^3.31.0
+  smooth_page_indicator: ^1.1.0
+  talker: ^4.2.3
+  talker_flutter: ^4.2.3
+  talker_riverpod_logger: ^1.0.3
   url_launcher: ^6.2.6
+  uuid: ^4.4.0
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/packages/obento/pubspec.lock
+++ b/packages/obento/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "2.1.1"
   budoux_dart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: budoux_dart
       sha256: "7211cfa7bc38beb00d1dfe9d1b9016a6089b0b84b45d6b0b20f66bf8dbd6ef3b"
@@ -202,7 +202,7 @@ packages:
     source: hosted
     version: "0.4.1"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "3.12.5"
   cloud_functions:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cloud_functions
       sha256: ddec68a2fbee603527c009bb20c6bd071559dfa87fda55d9d92052d1ebff5377
@@ -337,7 +337,7 @@ packages:
     source: hosted
     version: "6.0.0"
   cupertino_icons:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cupertino_icons
       sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
@@ -385,7 +385,7 @@ packages:
     source: hosted
     version: "1.2.0"
   device_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: device_info_plus
       sha256: eead12d1a1ed83d8283ab4c2f3fca23ac4082f29f25f29dff0f758f57d06ec91
@@ -425,7 +425,7 @@ packages:
     source: hosted
     version: "1.3.1"
   feedback:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: feedback
       sha256: "26769f73de6215add72074d24e4a23542e4c02a8fd1a873e7c93da5dc9c1d362"
@@ -449,7 +449,7 @@ packages:
     source: hosted
     version: "7.0.0"
   firebase_analytics:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_analytics
       sha256: dbf1e7ab22cfb1f4a4adb103b46a26276b4edc593d4a78ef6fb942bafc92e035
@@ -473,7 +473,7 @@ packages:
     source: hosted
     version: "0.5.7+7"
   firebase_app_check:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_app_check
       sha256: aac3b42cdf804b10cb1085c9902e5d1ef2f30e7cfc0c504e6f47519713d86829
@@ -497,7 +497,7 @@ packages:
     source: hosted
     version: "0.1.2+7"
   firebase_auth:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_auth
       sha256: cfc2d970829202eca09e2896f0a5aa7c87302817ecc0bdfa954f026046bf10ba
@@ -521,7 +521,7 @@ packages:
     source: hosted
     version: "5.12.0"
   firebase_core:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core
       sha256: "26de145bb9688a90962faec6f838247377b0b0d32cc0abecd9a4e43525fc856c"
@@ -545,7 +545,7 @@ packages:
     source: hosted
     version: "2.17.0"
   firebase_crashlytics:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_crashlytics
       sha256: "9897c01efaa950d2f6da8317d12452749a74dc45f33b46390a14cfe28067f271"
@@ -561,7 +561,7 @@ packages:
     source: hosted
     version: "3.6.35"
   firebase_performance:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_performance
       sha256: dbcfc300755c4bb866988de20a491f0b53e1a0d14c375a2c31aa53ca82174c5b
@@ -585,7 +585,7 @@ packages:
     source: hosted
     version: "0.1.6+7"
   firebase_remote_config:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_remote_config
       sha256: "653bd94b68e2c4e89eca10db90576101f1024151f39f2d4e7c64ae6a90a5f9c5"
@@ -617,7 +617,7 @@ packages:
     source: hosted
     version: "1.1.0"
   flex_color_scheme:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flex_color_scheme
       sha256: "32914024a4f404d90ff449f58d279191675b28e7c08824046baf06826e99d984"
@@ -749,7 +749,7 @@ packages:
     source: hosted
     version: "2.7.0"
   google_mobile_ads:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_mobile_ads
       sha256: e2d18992d30b2be77cb6976b931112fc3c4612feffb5eb7a8b036bd7a64934da
@@ -853,7 +853,7 @@ packages:
     source: hosted
     version: "2.1.3"
   in_app_review:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: in_app_review
       sha256: "99869244d09adc76af16bf8fd731dd13cef58ecafd5917847589c49f378cbb30"
@@ -925,7 +925,7 @@ packages:
     source: hosted
     version: "3.0.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
@@ -1053,7 +1053,7 @@ packages:
     source: hosted
     version: "2.1.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
@@ -1197,7 +1197,7 @@ packages:
     source: hosted
     version: "0.9.4"
   quick_actions:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quick_actions
       sha256: b17da113df7a7005977f64adfa58ccc49c829d3ccc6e8e770079a8c7fbf2da9e
@@ -1386,7 +1386,7 @@ packages:
     source: sdk
     version: "0.0.99"
   slang:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: slang
       sha256: "0d8a8cbfd7858ed2bd9164a79bfb664ea83f1e124740b28acd0618757fc87ecc"
@@ -1402,7 +1402,7 @@ packages:
     source: hosted
     version: "3.31.0"
   slang_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: slang_flutter
       sha256: f8400292be49c11697d94af58d7f7d054c91af759f41ffe71e4e5413871ffc62
@@ -1410,7 +1410,7 @@ packages:
     source: hosted
     version: "3.31.0"
   smooth_page_indicator:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: smooth_page_indicator
       sha256: "725bc638d5e79df0c84658e1291449996943f93bacbc2cec49963dbbab48d8ae"
@@ -1506,7 +1506,7 @@ packages:
     source: hosted
     version: "1.2.0"
   talker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker
       sha256: f876081a34027464e3f1ac785c7e470a5fca2515f4c8c277fb6f78a63e5cda1e
@@ -1514,7 +1514,7 @@ packages:
     source: hosted
     version: "4.2.3"
   talker_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker_flutter
       sha256: "45dab03948d8a611b97d396a782497d567f8fa5694466a2d306f84cfffca6910"
@@ -1530,7 +1530,7 @@ packages:
     source: hosted
     version: "4.2.3"
   talker_riverpod_logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: talker_riverpod_logger
       sha256: "186c4cd71abc7d15e661d0a2011d0208c860f12ec1359638cfd335f95925d505"
@@ -1610,7 +1610,7 @@ packages:
     source: hosted
     version: "2.2.2"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: "6ce1e04375be4eed30548f10a315826fd933c1e493206eab82eed01f438c8d2e"
@@ -1674,7 +1674,7 @@ packages:
     source: hosted
     version: "3.1.1"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"

--- a/packages/obento/pubspec.yaml
+++ b/packages/obento/pubspec.yaml
@@ -9,10 +9,24 @@ environment:
 
 dependencies:
   adaptive_dialog: ^2.1.0
+  budoux_dart: ^1.2.0
+  clock: ^1.1.1
   cloud_firestore: ^4.17.5
+  cloud_functions: ^4.7.6
   collection: ^1.18.0
   core:
     path: ../core
+  cupertino_icons: ^1.0.8
+  device_info_plus: ^10.1.0
+  feedback: ^3.1.0
+  firebase_analytics: ^10.10.7
+  firebase_app_check: ^0.2.2+7
+  firebase_auth: ^4.20.0
+  firebase_core: ^2.32.0
+  firebase_crashlytics: ^3.5.7
+  firebase_performance: ^0.9.4+7
+  firebase_remote_config: ^4.4.7
+  flex_color_scheme: ^7.3.1
   flutter:
     sdk: flutter
   flutter_hooks: ^0.20.5
@@ -21,15 +35,28 @@ dependencies:
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
   go_router: ^14.1.4
+  google_mobile_ads: ^5.1.0
   hooks_riverpod: ^2.5.1
+  in_app_review: ^2.0.9
   intersperse: ^2.0.0
   intl: any
   jovial_svg: ^1.1.21
+  json_annotation: ^4.9.0
   media_query_preview: ^0.0.2
+  package_info_plus: ^8.0.0
   pull_down_button: ^0.9.4
+  quick_actions: ^1.0.7
   riverpod_annotation: ^2.3.5
   share_plus: ^9.0.0
   shared_preferences: ^2.2.3
+  slang: ^3.31.0
+  slang_flutter: ^3.31.0
+  smooth_page_indicator: ^1.1.0
+  talker: ^4.2.3
+  talker_flutter: ^4.2.3
+  talker_riverpod_logger: ^1.0.3
+  url_launcher: ^6.2.6
+  uuid: ^4.4.0
 
 dev_dependencies:
   build_runner: ^2.4.11


### PR DESCRIPTION
`dependency: transitive` ではなく、`direct main` になるようにpubspec.yamlに追加

renovateがpub getしてくれないため。

revert #369